### PR TITLE
[WASI-NN] Add single token inference

### DIFF
--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -28,6 +28,8 @@ pub enum BackendError {
     TooLarge,
     #[error("WASI-NN Backend Error: Not Found")]
     NotFound,
+    #[error("WASI-NN Backend Error: EOS Found")]
+    EndOfSequence,
     #[error("Unknown Wasi-NN Backend Error Code `{0}`")]
     UnknownError(i32),
 }
@@ -43,6 +45,7 @@ impl From<i32> for BackendError {
             6 => Self::UnsupportedOperation,
             7 => Self::TooLarge,
             8 => Self::NotFound,
+            9 => Self::EndOfSequence,
             _ => Self::UnknownError(value),
         }
     }

--- a/rust/src/generated.rs
+++ b/rust/src/generated.rs
@@ -307,8 +307,36 @@ pub unsafe fn get_output(
     }
 }
 
+pub unsafe fn get_output_single(
+    context: GraphExecutionContext,
+    index: u32,
+    out_buffer: *mut u8,
+    out_buffer_max_size: BufferSize,
+) -> Result<BufferSize, NnErrno> {
+    let mut rp0 = MaybeUninit::<BufferSize>::uninit();
+    let ret = wasi_ephemeral_nn::get_output_single(
+        context as i32,
+        index as i32,
+        out_buffer as i32,
+        out_buffer_max_size as i32,
+        rp0.as_mut_ptr() as i32,
+    );
+    match ret {
+        0 => Ok(core::ptr::read(rp0.as_mut_ptr() as i32 as *const BufferSize)),
+        _ => Err(NnErrno(ret as u16)),
+    }
+}
+
 pub unsafe fn compute(context: GraphExecutionContext) -> Result<(), NnErrno> {
     let ret = wasi_ephemeral_nn::compute(context as i32);
+    match ret {
+        0 => Ok(()),
+        _ => Err(NnErrno(ret as u16)),
+    }
+}
+
+pub unsafe fn compute_single(context: GraphExecutionContext) -> Result<(), NnErrno> {
+    let ret = wasi_ephemeral_nn::compute_single(context as i32);
     match ret {
         0 => Ok(()),
         _ => Err(NnErrno(ret as u16)),
@@ -323,7 +351,9 @@ pub mod wasi_ephemeral_nn {
         pub fn init_execution_context(arg0: i32, arg1: i32) -> i32;
         pub fn set_input(arg0: i32, arg1: i32, arg2: i32) -> i32;
         pub fn get_output(arg0: i32, arg1: i32, arg2: i32, arg3: i32, arg4: i32) -> i32;
+        pub fn get_output_single(arg0: i32, arg1: i32, arg2: i32, arg3: i32, arg4: i32) -> i32;
         pub fn compute(arg0: i32) -> i32;
+        pub fn compute_single(arg0: i32) -> i32;
         pub fn load_by_name_with_config(
             arg0: i32,
             arg1: i32,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -49,6 +49,6 @@ mod error;
 mod graph;
 mod tensor;
 
-pub use error::Error;
+pub use error::{BackendError, Error};
 pub use graph::{ExecutionTarget, Graph, GraphBuilder, GraphEncoding, GraphExecutionContext};
 pub use tensor::TensorType;


### PR DESCRIPTION
This pull request is for adding the function of single token inference. To implement this function, we need to make modifications to 3 different repositories:

1. wasmedge-wasi-nn: Add two host functions `compute_single` and `get_output_single`
   - PR: https://github.com/second-state/wasmedge-wasi-nn/pull/3
2. WasmEdge: Implement the two WASI-NN functions `compute_single` and `get_output_single`
   - PR: https://github.com/WasmEdge/WasmEdge/pull/3103
3. WasmEdge-WASINN-examples: Add examples for single token inference
   - PR: https://github.com/second-state/WasmEdge-WASINN-examples/pull/75