### PR TITLE
Add ModelNotFound error

### DIFF
--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -34,6 +34,8 @@ pub enum BackendError {
     ContextFull,
     #[error("WASI-NN Backend Error: Prompt Too Long")]
     PromptTooLong,
+    #[error("WASI-NN Backend Error: Model Not Found")]
+    ModelNotFound,
     #[error("Unknown Wasi-NN Backend Error Code `{0}`")]
     UnknownError(i32),
 }
@@ -52,6 +54,7 @@ impl From<i32> for BackendError {
             100 => Self::EndOfSequence,
             101 => Self::ContextFull,
             102 => Self::PromptTooLong,
+            103 => Self::ModelNotFound,
             _ => Self::UnknownError(value),
         }
     }


### PR DESCRIPTION
To add `ModelNotFound` error to `wasmedge-wasi-nn` and use it in our WasmEdge WASINN examples, we need:

- Merge PR in wasmedge-wasi-nn
  - [PR](https://github.com/second-state/wasmedge-wasi-nn/pull/11)
- Merge PR in WasmEdge runtime
  - [PR](https://github.com/WasmEdge/WasmEdge/pull/3338)
- Release the new wasmedge-wasi-nn crate
- Update the WasmEdge WASINN examples to use the newer version of wasmedge-wasi-nn crate
  - [PR](https://github.com/second-state/WasmEdge-WASINN-examples/pull/130)