### PR TITLE
Add unload function

### DIFF
--- a/rust/src/generated.rs
+++ b/rust/src/generated.rs
@@ -351,6 +351,14 @@ pub unsafe fn fini_single(context: GraphExecutionContext) -> Result<(), NnErrno>
     }
 }
 
+pub unsafe fn unload(graph: Graph) -> Result<(), NnErrno> {
+    let ret = wasi_ephemeral_nn::unload(graph as i32);
+    match ret {
+        0 => Ok(()),
+        _ => Err(NnErrno(ret as u16)),
+    }
+}
+
 pub mod wasi_ephemeral_nn {
     #[link(wasm_import_module = "wasi_ephemeral_nn")]
     extern "C" {
@@ -370,5 +378,6 @@ pub mod wasi_ephemeral_nn {
             arg3: i32,
             arg4: i32,
         ) -> i32;
+        pub fn unload(arg0: i32) -> i32;
     }
 }

--- a/rust/src/graph.rs
+++ b/rust/src/graph.rs
@@ -222,6 +222,12 @@ impl Graph {
         let ctx_handle = syscall::init_execution_context(self.graph_handle)?;
         Ok(GraphExecutionContext { ctx_handle })
     }
+
+    /// Unload this graph.
+    #[inline(always)]
+    pub fn unload(&self) -> Result<(), Error> {
+        syscall::unload(self.graph_handle)
+    }
 }
 
 impl Display for Graph {
@@ -509,6 +515,17 @@ mod syscall {
             Err(Error::BackendError(BackendError::from(res)))
         }
     }
+
+    #[inline(always)]
+    pub(crate) fn unload(graph_handle: GraphHandle) -> Result<(), Error> {
+        let res = unsafe { wasi_ephemeral_nn::unload(graph_handle) };
+
+        if res == 0 {
+            Ok(())
+        } else {
+            Err(Error::BackendError(BackendError::from(res)))
+        }
+    }
 }
 
 // These stubbed out functions are only necessary for running `cargo test`.
@@ -574,6 +591,10 @@ mod syscall {
     }
 
     pub(crate) fn load_by_name_with_config(_: &str, _: &str) -> Result<GraphHandle, Error> {
+        unimplemented!("this crate is only intended to be used with `--target=wasm32-wasi`");
+    }
+
+    pub(crate) fn unload(_: GraphHandle) -> Result<(), Error> {
         unimplemented!("this crate is only intended to be used with `--target=wasm32-wasi`");
     }
 }


### PR DESCRIPTION
To add `unload()` function to `wasmedge-wasi-nn` and use it in our WasmEdge WASINN examples, we need:

- Merge PR in wasmedge-wasi-nn
  - [PR](https://github.com/second-state/wasmedge-wasi-nn/pull/12)
- Merge PR in WasmEdge runtime
  - [PR](https://github.com/WasmEdge/WasmEdge/pull/3350)
- Release the new wasmedge-wasi-nn crate
  - Will need to update Cargo.toml and README in another [PR]()
- Update the WasmEdge WASINN examples to use the newer version of wasmedge-wasi-nn crate
  - [PR]()