### PR TITLE
Add Piper backend

### DIFF
--- a/rust/src/generated.rs
+++ b/rust/src/generated.rs
@@ -139,6 +139,7 @@ pub const GRAPH_ENCODING_TENSORFLOW: GraphEncoding = GraphEncoding(2);
 pub const GRAPH_ENCODING_PYTORCH: GraphEncoding = GraphEncoding(3);
 pub const GRAPH_ENCODING_TENSORFLOWLITE: GraphEncoding = GraphEncoding(4);
 pub const GRAPH_ENCODING_AUTODETECT: GraphEncoding = GraphEncoding(5);
+pub const GRAPH_ENCODING_PIPER: GraphEncoding = GraphEncoding(11);
 impl GraphEncoding {
     pub const fn raw(&self) -> u8 {
         self.0
@@ -153,6 +154,7 @@ impl GraphEncoding {
             4 => "TENSORFLOWLITE",
             5 => "AUTODETECT",
             7 => "NUEURALSPEED",
+            11 => "PIPER",
             _ => unsafe { core::hint::unreachable_unchecked() },
         }
     }
@@ -164,6 +166,7 @@ impl GraphEncoding {
             3 => "",
             4 => "",
             5 => "",
+            11 => "",
             _ => unsafe { core::hint::unreachable_unchecked() },
         }
     }

--- a/rust/src/generated.rs
+++ b/rust/src/generated.rs
@@ -139,6 +139,8 @@ pub const GRAPH_ENCODING_TENSORFLOW: GraphEncoding = GraphEncoding(2);
 pub const GRAPH_ENCODING_PYTORCH: GraphEncoding = GraphEncoding(3);
 pub const GRAPH_ENCODING_TENSORFLOWLITE: GraphEncoding = GraphEncoding(4);
 pub const GRAPH_ENCODING_AUTODETECT: GraphEncoding = GraphEncoding(5);
+pub const GRAPH_ENCODING_GGML: GraphEncoding = GraphEncoding(6);
+pub const GRAPH_ENCODING_NEURALSPEED: GraphEncoding = GraphEncoding(7);
 pub const GRAPH_ENCODING_PIPER: GraphEncoding = GraphEncoding(11);
 impl GraphEncoding {
     pub const fn raw(&self) -> u8 {
@@ -153,7 +155,8 @@ impl GraphEncoding {
             3 => "PYTORCH",
             4 => "TENSORFLOWLITE",
             5 => "AUTODETECT",
-            7 => "NUEURALSPEED",
+            6 => "GGML",
+            7 => "NEURALSPEED",
             11 => "PIPER",
             _ => unsafe { core::hint::unreachable_unchecked() },
         }
@@ -166,6 +169,8 @@ impl GraphEncoding {
             3 => "",
             4 => "",
             5 => "",
+            6 => "",
+            7 => "",
             11 => "",
             _ => unsafe { core::hint::unreachable_unchecked() },
         }

--- a/rust/src/graph.rs
+++ b/rust/src/graph.rs
@@ -16,6 +16,7 @@ pub enum GraphEncoding {
     Autodetec,
     Ggml,
     NeuralSpeed,
+    Piper = 11,
 }
 
 /// Define where the graph should be executed.


### PR DESCRIPTION
I am working on [LFX Mentorship (Jun-Aug, 2024): Support piper as a new backend of the WASI-NN WasmEdge plugin #3381](https://github.com/WasmEdge/WasmEdge/issues/3381).
This PR adds piper backend ([index 11](https://www.github.com/WasmEdge/WasmEdge/issues/3491#issuecomment-2178008164)) to GraphEncoding.
I also fixed a typo for neural speed and I added some missing stuff for ggml and neural speed for consistency.
