### PR TITLE
Add BitNet backend to wasmedge-wasi-nn

### DIFF
--- a/rust/src/generated.rs
+++ b/rust/src/generated.rs
@@ -146,6 +146,8 @@ pub const GRAPH_ENCODING_WHISPER: GraphEncoding = GraphEncoding(9);
 pub const GRAPH_ENCODING_MLX: GraphEncoding = GraphEncoding(10);
 pub const GRAPH_ENCODING_PIPER: GraphEncoding = GraphEncoding(11);
 pub const GRAPH_ENCODING_CHATTTS: GraphEncoding = GraphEncoding(12);
+pub const GRAPH_ENCODING_OPENVINOGENAI: GraphEncoding = GraphEncoding(13);
+pub const GRAPH_ENCODING_BITNET: GraphEncoding = GraphEncoding(14);
 impl GraphEncoding {
     pub const fn raw(&self) -> u8 {
         self.0
@@ -166,6 +168,8 @@ impl GraphEncoding {
             10 => "MLX",
             11 => "PIPER",
             12 => "CHATTTS",
+            13 => "OPENVINOGENAI",
+            14 => "BITNET",
             _ => unsafe { core::hint::unreachable_unchecked() },
         }
     }
@@ -184,6 +188,8 @@ impl GraphEncoding {
             10 => "",
             11 => "",
             12 => "",
+            13 => "",
+            14 => "",
             _ => unsafe { core::hint::unreachable_unchecked() },
         }
     }

--- a/rust/src/graph.rs
+++ b/rust/src/graph.rs
@@ -21,6 +21,8 @@ pub enum GraphEncoding {
     Mlx,
     Piper,
     ChatTTS,
+    OpenVINOGenAI,
+    BitNet
 }
 
 /// Define where the graph should be executed.


### PR DESCRIPTION
I am working on adding support for BitNet (https://github.com/WasmEdge/WasmEdge/issues/4161)
This PR adds BitNet backend to Graph Encoding with index 14.
I have also included OpenVINOGenAI [(index 13](https://github.com/WasmEdge/WasmEdge/issues/3491#issuecomment-2693572414))